### PR TITLE
Fixed some slight mistakes in Recoil Control

### DIFF
--- a/[ZMH5] Helios/CSGO/Modules/NoRecoilModule.cs
+++ b/[ZMH5] Helios/CSGO/Modules/NoRecoilModule.cs
@@ -37,15 +37,20 @@ namespace _ZMH5__Helios.CSGO.Modules
                 return;
 
             var wep = lp.m_ActiveWeapon.Value;
-            if (Program.CurrentSettings.NoRecoil.NoRecoilSemiAuto)
+            if (!Program.CurrentSettings.NoRecoil.NoRecoilSemiAuto)
+            {
                 if (wep == null || !wep.IsValid)
                     return;
-                else
+            }
+            else
+            {
                 if (wep == null || !wep.IsValid || wep.IsPistol || wep.IsPumpgun || wep.IsSniper)
                 {
-                    DrawCrosshair();
+                    if (Program.CurrentSettings.NoRecoil.ShowCrosshair)
+                        DrawCrosshair();
                     return;
                 }
+            }
 
 
             if (Program.CurrentSettings.NoRecoil.ShowCrosshair)


### PR DESCRIPTION
NoRecoilSemiAuto settings would apply when turned off and vice versa. also if "off" the recoil crosshair would attempt to be drawn anyway if the weapons were semi-auto even if the setting for showing the crosshair was off, this has all been fixed.